### PR TITLE
fix 'get' call to resolve both data and pagination

### DIFF
--- a/lib/nodegram.js
+++ b/lib/nodegram.js
@@ -28,7 +28,7 @@ Nodegram.prototype.get = function(path, options) {
       var data = body ? body.data : [];
       var pagination = body ? body.pagination : {};
 
-      resolve(data, pagination);
+      resolve({data, pagination});
     });
   });
 };
@@ -110,7 +110,7 @@ Nodegram.prototype.buildQueryParams = function(options) {
   }
 
   return '';
-}
+};
 
 Nodegram.prototype.buildPath = function(path, options) {
   for (var prop in options) {
@@ -124,6 +124,6 @@ Nodegram.prototype.buildPath = function(path, options) {
     path: path,
     options: options
   };
-}
+};
 
 module.exports = Nodegram;

--- a/lib/nodegram.js
+++ b/lib/nodegram.js
@@ -28,7 +28,10 @@ Nodegram.prototype.get = function(path, options) {
       var data = body ? body.data : [];
       var pagination = body ? body.pagination : {};
 
-      resolve({data, pagination});
+      resolve({
+        data: data,
+        pagination: pagination
+      });
     });
   });
 };


### PR DESCRIPTION
Pagination is not reachable when calling `get`.
It is not possible to resolve 2 parameters in a promise callback. You have to use an object to encapsulate multiple variables.
